### PR TITLE
Fix restart issue with FizzyoFramework

### DIFF
--- a/Assets/Fizzyo/Scripts/FizzyoFramework/FizzyoFramework.cs
+++ b/Assets/Fizzyo/Scripts/FizzyoFramework/FizzyoFramework.cs
@@ -92,10 +92,10 @@ namespace Fizzyo
                     Debug.LogWarning("[Singleton] Instance '" + typeof(FizzyoFramework) +
                         "' already destroyed on application quit." +
                         " Won't create again - returning null.");
-               //     return null;
+                    //     return null;
                 }
 
-               // lock (_lock)
+                // lock (_lock)
                 {
                     if (_instance == null)
                     {
@@ -187,7 +187,8 @@ namespace Fizzyo
         private void Update()
         {
             //update the breath recoginiser
-            if (Device != null) {
+            if (Device != null)
+            {
                 Recogniser.AddSample(Time.deltaTime, Device.Pressure());
             }
 
@@ -245,7 +246,7 @@ namespace Fizzyo
         /// false if data is not loaded and playing offline
         /// </returns>
         public bool Load()
-            {
+        {
             //Login to server
 
             if (showLoginAutomatically)
@@ -253,11 +254,11 @@ namespace Fizzyo
                 LoginReturnType loginResult = User.Login();
 
 
-            if (loginResult != LoginReturnType.SUCCESS)
-            {
-                PlayOffline();
-                return false;
-            }
+                if (loginResult != LoginReturnType.SUCCESS)
+                {
+                    PlayOffline();
+                    return false;
+                }
             }
             else
             {
@@ -281,20 +282,26 @@ namespace Fizzyo
         /// Sets up the player preferences to allow the user to play offline
         /// </summary>
         private static void PlayOffline()
-            {
-               // ResetPlayerPrefs();
-            }
+        {
+            // ResetPlayerPrefs();
+        }
 
-            /// <summary>
-            /// Resets all of the player preferences
-            /// </summary>
+        /// <summary>
+        /// Resets all of the player preferences
+        /// </summary>
 
 
 
-            public void OnDestroy()
-            {
-                applicationIsQuitting = true;
-            }
+        public void OnDestroy()
+        {
+            applicationIsQuitting = true;
+        }
+
+        private void OnEnable()
+        {
+            applicationIsQuitting = false;
+
+        }
 
 
     }

--- a/Assets/Fizzyo/Scripts/SceneScripts/PlayerBehaviour.cs
+++ b/Assets/Fizzyo/Scripts/SceneScripts/PlayerBehaviour.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using Fizzyo;
+using UnityEngine.SceneManagement;
 
 public class PlayerBehaviour : MonoBehaviour {
 
@@ -24,5 +25,11 @@ public class PlayerBehaviour : MonoBehaviour {
         y = Mathf.Max(y, 0);
 
         transform.position = new Vector3(x,y, 0);
+
+        if (Input.GetKeyDown(KeyCode.Q))
+        {
+            Debug.Log("Level Restarted");
+            SceneManager.LoadScene("ExampleLevel");
+        }
 	}
 }


### PR DESCRIPTION
Allows the Fizzyo singleton to be restarted without causing the ApplicatonIsQuitting error to spam the console.

Added an action in the ExampleLevel to press Q to restart the level for testing.